### PR TITLE
Update libgit2 to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ repository = "https://github.com/Techcable/gitpatcher"
 slog = "2.7"
 
 [workspace.dependencies.git2]
-version = "0.17"
+version = "0.18"
 # We don't need https
 default-features = false
 

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -33,4 +33,7 @@ slog-term = "2.9"
 
 [build-dependencies]
 # Already using libgit2 for engine, might as well use for versions
-vergen = { version = "8.2", features = ["git", "git2"] }
+#
+# TODO: Switch back to git2.
+# Right now can't use it because of version conflict
+vergen = { version = "8.2", features = ["git", "gitcl"] }


### PR DESCRIPTION
Update libgit2 to 0.18

Requires dropping the `git2` feature from [vergen](https://lib.rs/vergen) and instead using `gitcl`.
This is because vergen still uses the old version of libgit2.

The `gitcl` feature for vergen requires that `git` be installed on the path,
which may not be the case on windows machines.
